### PR TITLE
Pot pubkey

### DIFF
--- a/.cargo/config
+++ b/.cargo/config
@@ -3,3 +3,6 @@ rustflags = ["-C", "target-feature=+atomics,+bulk-memory,+mutable-globals"]
 
 [unstable]
 build-std = ["panic_abort", "std"]
+
+[build]
+target = "x86_64-unknown-linux-gnu"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,13 +16,14 @@ default = ["console_error_panic_hook"]
 [dependencies]
 ark-serialize = { version = "0.3" }
 ark-bls12-381 = "0.3.0"
+ark-ec = { version = "0.3", default-features = false }
 eyre = "0.6.8"
 getrandom = { version = "0.2", features = ["js"] }
 hex = "0.4.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 serde_json = "1.0.48"
-small-powers-of-tau = { git = "https://github.com/NicoSerranoP/small-powers-of-tau" }
+small-powers-of-tau = { path = "../small-powers-of-tau" }
 
 [target."wasm32-unknown-unknown".dependencies]
 js-sys = { version = "0.3.58"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,7 +4,7 @@ version = "0.1.0"
 authors = ["Nico Serrano"]
 edition = "2021"
 description = "Small Powers of Tau Rust code wrapper to be used in browsers for participants' contributions"
-repository = "https://github.com/zkparty/small-powers-of-tau"
+repository = "https://github.com/zkparty/wrapper-small-pot"
 license = "ISC"
 
 [lib]
@@ -23,7 +23,7 @@ hex = "0.4.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 serde_json = "1.0.48"
-small-powers-of-tau = { path = "../small-powers-of-tau" }
+small-powers-of-tau = { git = "https://github.com/NicoSerranoP/small-powers-of-tau" }
 
 [target."wasm32-unknown-unknown".dependencies]
 js-sys = { version = "0.3.58"}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,8 +15,10 @@ default = ["console_error_panic_hook"]
 
 [dependencies]
 ark-serialize = { version = "0.3" }
+ark-bls12-381 = "0.3.0"
 eyre = "0.6.8"
 getrandom = { version = "0.2", features = ["js"] }
+hex = "0.4.3"
 serde = { version = "1", features = ["derive"] }
 serde-wasm-bindgen = "0.4"
 serde_json = "1.0.48"

--- a/README.md
+++ b/README.md
@@ -22,6 +22,12 @@ To build and run the wrapper code and test it using the code inside the `main.rs
 
 *Note:* In Ubuntu/Linux you can use target `x86_64-unknown-linux-gnu`, in Windows you can use `WINDOWS_TARGET_HERE`
 
+
+### **Test**
+To build and run tests, run:
+
+``` cargo test ```
+
 &nbsp;
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -172,13 +172,6 @@ fn json_to_contribution(json: String) -> Result<Contribution> {
     Ok(contribution)
 }
 
-fn contribution_to_json(contribution: Contribution) -> Result<String> {
-    let contribution_json = ContributionJSON::from(&contribution);
-    let contribution_string = serde_json::to_string(&contribution_json)
-    .expect("error serializing contribution json to string");
-    Ok(contribution_string)
-}
-
 fn json_to_update_proofs(json: String) -> Result<[UpdateProof; NUM_CEREMONIES]> {
     let update_proofs_value = serde_json::from_str(&json)
     .expect("error parsing update proof string to json");

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ mod wasm;
 use eyre::Result;
 use std::{fs::File, path::Path};
 use ark_serialize::{Read, Write};
+use ark_ec::{ProjectiveCurve};
 use small_powers_of_tau::update_proof::UpdateProof;
 use small_powers_of_tau::sdk::NUM_CEREMONIES;
 use small_powers_of_tau::sdk::contribution::{
@@ -14,6 +15,9 @@ use small_powers_of_tau::sdk::contribution::{
     Contribution,
 };
 use small_powers_of_tau::keypair::{PrivateKey};
+use small_powers_of_tau::interop_point_encoding::{
+    deserialize_g2, serialize_g2, G2_SERIALISED_SIZE,
+};
 use hex::FromHex;
 
 /**
@@ -122,7 +126,9 @@ pub fn get_pot_pubkeys(string_secrets: [&str; NUM_CEREMONIES]) -> Result<Vec<Str
             let bytes = <[u8; 12]>::from_hex(secret_stripped).unwrap();
             if !bytes.is_empty() {
                 let private_key = PrivateKey::from_bytes(&bytes);
-                pot_pubkeys.push(private_key.to_public().to_string());
+                let mut a = hex::encode(serialize_g2(&private_key.to_public().into_affine()));
+                a.insert_str(0, "0x");
+                pot_pubkeys.push(a);
             }
         }
     }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,10 +2,13 @@
 mod wasm;
 
 use eyre::Result;
+use hex::FromHex;
 use std::{fs::File, path::Path};
 use ark_serialize::{Read, Write};
 use ark_ec::{ProjectiveCurve};
+use small_powers_of_tau::keypair::PrivateKey;
 use small_powers_of_tau::update_proof::UpdateProof;
+use small_powers_of_tau::interop_point_encoding::serialize_g2;
 use small_powers_of_tau::sdk::NUM_CEREMONIES;
 use small_powers_of_tau::sdk::contribution::{
     contribution_subgroup_check,
@@ -14,11 +17,6 @@ use small_powers_of_tau::sdk::contribution::{
     ContributionJSON,
     Contribution,
 };
-use small_powers_of_tau::keypair::{PrivateKey};
-use small_powers_of_tau::interop_point_encoding::{
-    deserialize_g2, serialize_g2, G2_SERIALISED_SIZE,
-};
-use hex::FromHex;
 
 /**
  * We'll use this function in the cli

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -110,18 +110,23 @@ fn verify_update(old_contribution: Contribution, new_contribution: Contribution,
     Ok(result)
 }
 
-fn get_pubkeys(secrets: [String; NUM_CEREMONIES]) -> Result<Vec<String>> {
-    let mut keypairs = Vec::with_capacity(NUM_CEREMONIES);
-    for (i, secret_hex) in secrets.into_iter().enumerate() {
-        if let Some(stripped_point_json) = secret_hex.strip_prefix("0x") {
-            let bytes = <[u8; 4]>::from_hex(stripped_point_json).ok();
-            if (bytes.is_some()) {
-                let priv_key = PrivateKey::from_bytes(&bytes.unwrap());
-                keypairs.push(priv_key.to_public());
+/**
+ * Core function: get potPubkeys from secrets
+ */
+pub fn get_pot_pubkeys(string_secrets: [&str; NUM_CEREMONIES]) -> Result<Vec<String>> {
+    let mut pot_pubkeys = Vec::with_capacity(NUM_CEREMONIES);
+    for(_i, secret_string) in string_secrets.into_iter().enumerate() {
+        let secret_hex = secret_string.to_string();
+        if let Some(secret_stripped) = secret_hex.strip_prefix("0x") {
+            // TODO: keep in mind that secrets needs at least 12 characters
+            let bytes = <[u8; 12]>::from_hex(secret_stripped).unwrap();
+            if !bytes.is_empty() {
+                let private_key = PrivateKey::from_bytes(&bytes);
+                pot_pubkeys.push(private_key.to_public().to_string());
             }
         }
     }
-    Ok(keypairs)
+    Ok(pot_pubkeys)
 }
 
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -13,6 +13,8 @@ use small_powers_of_tau::sdk::contribution::{
     ContributionJSON,
     Contribution,
 };
+use small_powers_of_tau::keypair::{PrivateKey};
+use hex::FromHex;
 
 /**
  * We'll use this function in the cli
@@ -106,6 +108,20 @@ fn verify_update(old_contribution: Contribution, new_contribution: Contribution,
         secrets,
     );
     Ok(result)
+}
+
+fn get_pubkeys(secrets: [String; NUM_CEREMONIES]) -> Result<Vec<String>> {
+    let mut keypairs = Vec::with_capacity(NUM_CEREMONIES);
+    for (i, secret_hex) in secrets.into_iter().enumerate() {
+        if let Some(stripped_point_json) = secret_hex.strip_prefix("0x") {
+            let bytes = <[u8; 4]>::from_hex(stripped_point_json).ok();
+            if (bytes.is_some()) {
+                let priv_key = PrivateKey::from_bytes(&bytes.unwrap());
+                keypairs.push(priv_key.to_public());
+            }
+        }
+    }
+    Ok(keypairs)
 }
 
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -13,15 +13,14 @@ fn main() {
     let out_path = "updatedContribution.json";
     let proof_path = "updateProofs.json";
     let string_secrets = [
-        "0xaabbccddeeff001122334455",
-        "0x001122334455667788aa99bb",
-        "0x0a1b2c3d4e5f0a1b2c3d4e5f",
-        "0x0a9a8a7b6c5c4d3f11223344",
+        "0x6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+        "0xd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35",
+        "0x4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce",
+        "0x4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a",
     ];
 
-    let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
-    println!("{:?}", pot_pubkeys[0]);
-    /*
+
+
     println!("subgroup check with file initialized");
     let start_subgroup_check = Instant::now();
     check_subgroup_with_file(in_path).unwrap();
@@ -48,7 +47,12 @@ fn main() {
         string_secrets,
     ).unwrap();
     println!("verify update time: {:?}", start_verify_update.elapsed());
-    */
+
+    println!("get potPubkeys from secrets initialized");
+    let start_get_pot_pubkeys = Instant::now();
+    let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
+    println!("{:?}", pot_pubkeys);
+    println!("get potPubkeys time: {:?}", start_get_pot_pubkeys.elapsed());
 }
 
 
@@ -61,18 +65,18 @@ mod tests {
     fn secrets_to_pubkey_test() {
         // This test ensures that pubkeys dericvation appears correct
         let string_secrets = [
-            "0xaabbccddeeff001122334455",
-            "0x001122334455667788aa99bb",
-            "0x0a1b2c3d4e5f0a1b2c3d4e5f",
-            "0x0a9a8a7b6c5c4d3f11223344",
+            "0x6b86b273ff34fce19d6b804eff5a3f5747ada4eaa22f1d49c01e52ddb7875b4b",
+            "0xd4735e3a265e16eee03f59718b9b5d03019c07d8b6c51f90da3a666eec13ab35",
+            "0x4e07408562bedb8b60ce05c1decfe3ad16b72230967de01f640b7e4729b49fce",
+            "0x4b227777d4dd1fc61c6f884f48641d02b4d121d3fd328cb08b5531fcacdabf8a",
         ];
-    
+
         let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
         println!("{:?}", pot_pubkeys[0]);
         println!("{:?}", pot_pubkeys[1]);
         println!("{:?}", pot_pubkeys[2]);
         println!("{:?}", pot_pubkeys[3]);
-    
+
         assert_eq!(pot_pubkeys[0].get(0..2).unwrap(), String::from("0x"));
         assert_eq!(pot_pubkeys[0].len(), 194);
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,6 +3,7 @@ use wrapper_small_pot::{
     contribute_with_file,
     check_subgroup_with_file,
     verify_update_with_file,
+    get_pot_pubkeys,
 };
 
 fn main() {
@@ -11,9 +12,16 @@ fn main() {
     let in_path = "initialContribution.json";
     let out_path = "updatedContribution.json";
     let proof_path = "updateProofs.json";
-    let string_secrets = ["0xdeadbeef","0x001122334455667788aa99bb","0x0a1b2c3d4e5f", "0x0a9a8a7b6c5c4d3f"];
+    let string_secrets = [
+        "0xaabbccddeeff001122334455",
+        "0x001122334455667788aa99bb",
+        "0x0a1b2c3d4e5f0a1b2c3d4e5f",
+        "0x0a9a8a7b6c5c4d3f11223344",
+    ];
 
-
+    let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
+    println!("{:?}", pot_pubkeys[0]);
+    /*
     println!("subgroup check with file initialized");
     let start_subgroup_check = Instant::now();
     check_subgroup_with_file(in_path).unwrap();
@@ -40,4 +48,5 @@ fn main() {
         string_secrets,
     ).unwrap();
     println!("verify update time: {:?}", start_verify_update.elapsed());
+    */
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     ];
 
     let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
-    println!("{:?}", pot_pubkeys[1]);
+    println!("{:?}", pot_pubkeys[0]);
     /*
     println!("subgroup check with file initialized");
     let start_subgroup_check = Instant::now();
@@ -49,4 +49,31 @@ fn main() {
     ).unwrap();
     println!("verify update time: {:?}", start_verify_update.elapsed());
     */
+}
+
+
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn secrets_to_pubkey_test() {
+        // This test ensures that pubkeys dericvation appears correct
+        let string_secrets = [
+            "0xaabbccddeeff001122334455",
+            "0x001122334455667788aa99bb",
+            "0x0a1b2c3d4e5f0a1b2c3d4e5f",
+            "0x0a9a8a7b6c5c4d3f11223344",
+        ];
+    
+        let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
+        println!("{:?}", pot_pubkeys[0]);
+        println!("{:?}", pot_pubkeys[1]);
+        println!("{:?}", pot_pubkeys[2]);
+        println!("{:?}", pot_pubkeys[3]);
+    
+        assert_eq!(pot_pubkeys[0].get(0..2).unwrap(), String::from("0x"));
+        assert_eq!(pot_pubkeys[0].len(), 194);
+    }
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -20,7 +20,7 @@ fn main() {
     ];
 
     let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
-    println!("{:?}", pot_pubkeys[0]);
+    println!("{:?}", pot_pubkeys[1]);
     /*
     println!("subgroup check with file initialized");
     let start_subgroup_check = Instant::now();

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -42,9 +42,9 @@ pub fn contribute_wasm(input: &str, secret_0: &str, secret_1: &str, secret_2: &s
 }
 
 #[wasm_bindgen]
-pub fn subgroup_check_wasm(input: &str) -> String {
+pub fn subgroup_check_wasm(input: &str) -> bool {
     let result = check_subgroup_with_string(input.to_string()).unwrap();
-    return format!("{}", result);
+    return result;
 }
 
 #[wasm_bindgen]

--- a/src/wasm.rs
+++ b/src/wasm.rs
@@ -7,6 +7,7 @@ use crate::{
     check_subgroup_with_string,
     verify_update_with_string,
     contribute_with_string,
+    get_pot_pubkeys,
 };
 
 #[derive(Serialize, Deserialize)]
@@ -61,4 +62,16 @@ pub fn verify_update_wasm(input: &str, output: &str, proofs: &str, secret_0: &st
         string_secrets
     ).unwrap();
     return format!("{}", result);
+}
+
+#[wasm_bindgen]
+pub fn get_pot_pubkeys_wasm(secret_0: &str, secret_1: &str, secret_2: &str, secret_3: &str) -> JsValue {
+    let string_secrets = [
+        secret_0,
+        secret_1,
+        secret_2,
+        secret_3,
+    ];
+    let pot_pubkeys = get_pot_pubkeys(string_secrets).unwrap();
+    return serde_wasm_bindgen::to_value(&pot_pubkeys).unwrap();
 }

--- a/wasm/wasm-worker.js
+++ b/wasm/wasm-worker.js
@@ -30,18 +30,7 @@ onmessage = async (event) => {
             const endTime = performance.now();
 
             const postContribution = JSON.parse(result.contribution);
-            const contributions = postContribution.contributions;
-            const proofs = JSON.parse(result.proofs);
-            contributions.forEach((contribution, i) => {
-                contribution.potPubkey = proofs[i][0]; //commitment_to_secret
-            });
-            const newResult = {
-                'contribution': JSON.stringify({
-                    'contributions': contributions
-                }),
-                'proofs': result.proofs,
-            }
-            console.log(newResult);
+            console.log(postContribution);
 
             console.log(`Contribution took ${endTime - startTime} milliseconds`)
         });

--- a/wasm/wasm-worker.js
+++ b/wasm/wasm-worker.js
@@ -1,4 +1,8 @@
-import init, {init_threads, contribute_wasm} from "./pkg/wrapper_small_pot.js";
+import init, {
+    init_threads,
+    contribute_wasm,
+    subgroup_check_wasm
+} from "./pkg/wrapper_small_pot.js";
 
 onmessage = async (event) => {
     const entropy = event.data;
@@ -31,8 +35,10 @@ onmessage = async (event) => {
 
             const postContribution = JSON.parse(result.contribution);
             console.log(postContribution);
+            console.log(`Contribution took ${endTime - startTime} milliseconds`);
 
-            console.log(`Contribution took ${endTime - startTime} milliseconds`)
+            const checkContribution = subgroup_check_wasm(result.contribution);
+            console.log(checkContribution)
         });
     });
 }


### PR DESCRIPTION
Get the potPubkeys before computing the contribution so the participants can sign their own potPubkeys. We decided to sign the potPubkeys before and not after because the signing process with Metamask needs user action and this could cause the participant to reach contribution deadline and be banned from uploading the contribution